### PR TITLE
Draft: Update Helm chart version and improve storage configuration

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: toledo base helm
 name: toledo
-version: 1.0.5
+version: 1.0.6

--- a/charts/templates/pvc-tests.yaml
+++ b/charts/templates/pvc-tests.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ .Release.Name }}-pvc-tests
 spec:
-  storageClassName: gp3
+  storageClassName: {{ .Values.volume.storageClassName }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/charts/templates/pvc.yaml
+++ b/charts/templates/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ .Release.Name }}-pvc
 spec:
-  storageClassName: gp3
+  storageClassName: {{ .Values.volume.storageClassName }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -17,9 +17,9 @@ image:
 
 ingress:
   hostname: "localhost"
-#  cfIpList: ''
   annotations: []
 
 volume:
+  storageClassName: gp3
   size: 1Gi
   testSize: 20Gi


### PR DESCRIPTION
Bump chart version to 1.0.6 and switch PVC storageClassName to use a configurable value from values.yaml. This enhances flexibility for storage provisioning and keeps the chart settings more dynamic.