### PR TITLE
FP-4199: Add `MISMATCH_THRESHOLD` to configurations and BackstopJS

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.2.0"
 description: toledo base helm
 name: toledo
-version: 1.6.1
+version: 1.7.1

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.2.0"
 description: toledo base helm
 name: toledo
-version: 1.7.1
+version: 1.7.2

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
               value: {{ .Values.clientAddr }}
             - name: REPO_URL
               value: {{ .Values.repoUrl }}
+            - name: MISMATCH_THRESHOLD
+              value: {{ .Values.misMatchThreshold }}
           image: {{ printf "ghcr.io/upstars-global/toledo:%s" ( .Values.image.tag | default .Chart.AppVersion ) }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - name: REPO_URL
               value: {{ .Values.repoUrl }}
             - name: MISMATCH_THRESHOLD
-              value: {{ .Values.misMatchThreshold }}
+              value: {{ .Values.misMatchThreshold | quote }}
           image: {{ printf "ghcr.io/upstars-global/toledo:%s" ( .Values.image.tag | default .Chart.AppVersion ) }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -4,6 +4,7 @@ scenarios: ''
 clientAddr: ''
 slackChanel: ''
 repoUrl: ''
+misMatchThreshold: ''
 replicas: 1
 port: 3000
 

--- a/charts/values/development.yaml
+++ b/charts/values/development.yaml
@@ -4,5 +4,6 @@ slackChanel: ''
 clientAddr: ''
 defaultService: ''
 repoUrl: ''
+misMatchThreshold: ''
 ingress:
   hostname: ''

--- a/charts/values/staging.yaml
+++ b/charts/values/staging.yaml
@@ -4,5 +4,6 @@ slackChanel: ''
 clientAddr: ''
 defaultService: ''
 repoUrl: ''
+misMatchThreshold: ''
 ingress:
   hostname: ''

--- a/server/backstop/index.js
+++ b/server/backstop/index.js
@@ -1,4 +1,5 @@
 import getBaseScenarios from '../helpers/getScenarios';
+import { MISMATCH_THRESHOLD } from '../config';
 
 const backstop = require('backstopjs');
 const fs = require('fs');
@@ -24,6 +25,7 @@ function getScenarios() {
         scenarios.push({
             ...defaultScenarios,
             ...config,
+            misMatchThreshold: MISMATCH_THRESHOLD
         });
     });
 

--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -7,3 +7,4 @@ export const CLIENT_ADDR = process.env.CLIENT_ADDR;
 export const MOCK_ADDR = process.env.MOCK_ADDR;
 export const REPO_URL = process.env.REPO_URL;
 export const NODE_ENV = process.env.NODE_ENV;
+export const MISMATCH_THRESHOLD = process.env.MISMATCH_THRESHOLD || 0.5;


### PR DESCRIPTION
- Added `MISMATCH_THRESHOLD` support to `values.yaml`, `index.ts`, and BackstopJS configuration for flexible threshold handling.
- Updated deployment templates to include the new configuration.