### PR TITLE
feat(api): add reference list endpoint

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.2.0"
 description: toledo base helm
 name: toledo
-version: 1.8.4
+version: 1.9.0

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
     "dotenv": "^16.4.7",
     "du": "^1.0.0",
     "express": "^4.21.2",
+    "express-rate-limit": "^8.5.2",
     "p-queue": "^8.1.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",

--- a/server/routes/api/index.ts
+++ b/server/routes/api/index.ts
@@ -2,6 +2,7 @@ import express, { Router } from 'express';
 import startRoute from './start';
 import testList from './test-list';
 import reference from './reference';
+import referenceList from './reference-list';
 import deleteRoute from './delete';
 import appList from './app-list';
 import spaseUsage from './spaseUsage';
@@ -16,6 +17,7 @@ export default function apiRouter(): Router {
     router.get('/test-list', testList);
     router.get('/app-list', appList);
     router.get('/reference', reference);
+    router.get('/reference-list', referenceList);
     router.post('/reference-select-scenarios', reference);
     router.get('/delete', deleteRoute);
     router.get('/spase-usage', spaseUsage);

--- a/server/routes/api/index.ts
+++ b/server/routes/api/index.ts
@@ -1,4 +1,5 @@
 import express, { Router } from 'express';
+import { rateLimit } from 'express-rate-limit';
 import startRoute from './start';
 import testList from './test-list';
 import reference from './reference';
@@ -8,6 +9,12 @@ import appList from './app-list';
 import spaseUsage from './spaseUsage';
 import { getScenariosProject } from './test-scenarios';
 
+const referenceListLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    limit: 60,
+    standardHeaders: true,
+    legacyHeaders: false,
+});
 
 export default function apiRouter(): Router {
     const router = express.Router();
@@ -17,7 +24,7 @@ export default function apiRouter(): Router {
     router.get('/test-list', testList);
     router.get('/app-list', appList);
     router.get('/reference', reference);
-    router.get('/reference-list', referenceList);
+    router.get('/reference-list', referenceListLimiter, referenceList);
     router.post('/reference-select-scenarios', reference);
     router.get('/delete', deleteRoute);
     router.get('/spase-usage', spaseUsage);

--- a/server/routes/api/reference-list.ts
+++ b/server/routes/api/reference-list.ts
@@ -13,11 +13,15 @@ interface IReferenceListItem {
     image: string | null
 }
 
+interface IReferenceImages {
+    [label: string]: string
+}
+
 const REFERENCE_IMAGES_PATH = path.join(__dirname, '../../backstop/reference/images');
-const LOCAL_CHART_SCENARIOS_PATH = path.join(__dirname, '../../../charts/scenarios/index.json');
 const REFERENCE_IMAGE_ROUTE = '/reference';
 const CONFIG_ID = 'backstop_default';
 const IMAGE_EXTENSION_REGEXP = /\.(png|jpe?g)$/i;
+const DESKTOP_IMAGE_REGEXP = /_desktop\.(png|jpe?g)$/i;
 
 function makeSafeLabel(label: string): string {
     return label
@@ -29,36 +33,39 @@ function escapeRegExp(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function getReferenceImage(label: string, files: string[]): string | null {
-    const scenarioPattern = new RegExp(`^${escapeRegExp(CONFIG_ID)}_${escapeRegExp(makeSafeLabel(label))}_\\d+_`);
-    const scenarioFiles = files.filter((file) => (
-        scenarioPattern.test(file)
-    ));
+function getReferenceImages(files: string[], scenarios: IScenario[]): IReferenceImages {
+    const labels = Array.from(new Set(
+        scenarios
+            .map(({ label }) => label && makeSafeLabel(label))
+            .filter(Boolean) as string[]
+    )).sort((a, b) => b.length - a.length);
 
-    const image = scenarioFiles.find((file) => /_desktop\.(png|jpe?g)$/i.test(file)) || scenarioFiles[0];
+    if (!labels.length) {
+        return {};
+    }
 
-    return image ? `${REFERENCE_IMAGE_ROUTE}/${image}` : null;
+    const labelPattern = labels
+        .map(escapeRegExp)
+        .join('|');
+    const scenarioPattern = new RegExp(`^${escapeRegExp(CONFIG_ID)}_(${labelPattern})_\\d+_`);
+
+    return files.reduce<IReferenceImages>((accumulator, file) => {
+        const [, label] = file.match(scenarioPattern) || [];
+
+        if (!label || (accumulator[label] && !DESKTOP_IMAGE_REGEXP.test(file))) {
+            return accumulator;
+        }
+
+        accumulator[label] = file;
+
+        return accumulator;
+    }, {});
 }
 
-function getReferenceScenarios(): IScenario[] {
-    let scenarios: IScenario[] = [];
+function getReferenceImage(label: string, images: IReferenceImages): string | null {
+    const image = images[makeSafeLabel(label)];
 
-    try {
-        scenarios = getScenarios() as IScenario[];
-    } catch (err) {
-        console.log(err);
-    }
-
-    if (scenarios.length) {
-        return scenarios;
-    }
-
-    try {
-        return JSON.parse(fs.readFileSync(LOCAL_CHART_SCENARIOS_PATH, 'utf8')) as IScenario[];
-    } catch (err) {
-        console.log(err);
-        return scenarios;
-    }
+    return image ? `${REFERENCE_IMAGE_ROUTE}/${image}` : null;
 }
 
 /**
@@ -76,7 +83,7 @@ function getReferenceScenarios(): IScenario[] {
  *      200:
  *         description: Список сценариев с референсными изображениями
  */
-export default function referenceList(req: Request, res: Response) {
+export default function referenceList(_req: Request, res: Response) {
     let files: string[] = [];
 
     try {
@@ -86,20 +93,22 @@ export default function referenceList(req: Request, res: Response) {
         console.log(err);
     }
 
-    const list = getReferenceScenarios().reduce<IReferenceListItem[]>((accumulator, scenario) => {
+    const scenarios = getScenarios() as IScenario[];
+    const images = getReferenceImages(files, scenarios);
+
+    const list = scenarios.reduce<IReferenceListItem[]>((accumulator, scenario) => {
         if (!scenario.label) {
             return accumulator;
         }
 
         accumulator.push({
             name: scenario.label,
-            image: getReferenceImage(scenario.label, files),
+            image: getReferenceImage(scenario.label, images),
         });
 
         return accumulator;
     }, []);
 
     res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Content-Type', 'application/json');
-    res.send(list);
+    res.json(list);
 }

--- a/server/routes/api/reference-list.ts
+++ b/server/routes/api/reference-list.ts
@@ -1,0 +1,105 @@
+import { Request, Response } from 'express';
+import fs from 'fs';
+import path from 'path';
+
+import getScenarios from '../../helpers/getScenarios';
+
+interface IScenario {
+    label?: string
+}
+
+interface IReferenceListItem {
+    name: string,
+    image: string | null
+}
+
+const REFERENCE_IMAGES_PATH = path.join(__dirname, '../../backstop/reference/images');
+const LOCAL_CHART_SCENARIOS_PATH = path.join(__dirname, '../../../charts/scenarios/index.json');
+const REFERENCE_IMAGE_ROUTE = '/reference';
+const CONFIG_ID = 'backstop_default';
+const IMAGE_EXTENSION_REGEXP = /\.(png|jpe?g)$/i;
+
+function makeSafeLabel(label: string): string {
+    return label
+        .replace(/[ /]/g, '_')
+        .replace(/[^a-z0-9_-]/gi, '');
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function getReferenceImage(label: string, files: string[]): string | null {
+    const scenarioPattern = new RegExp(`^${escapeRegExp(CONFIG_ID)}_${escapeRegExp(makeSafeLabel(label))}_\\d+_`);
+    const scenarioFiles = files.filter((file) => (
+        scenarioPattern.test(file)
+    ));
+
+    const image = scenarioFiles.find((file) => /_desktop\.(png|jpe?g)$/i.test(file)) || scenarioFiles[0];
+
+    return image ? `${REFERENCE_IMAGE_ROUTE}/${image}` : null;
+}
+
+function getReferenceScenarios(): IScenario[] {
+    let scenarios: IScenario[] = [];
+
+    try {
+        scenarios = getScenarios() as IScenario[];
+    } catch (err) {
+        console.log(err);
+    }
+
+    if (scenarios.length) {
+        return scenarios;
+    }
+
+    try {
+        return JSON.parse(fs.readFileSync(LOCAL_CHART_SCENARIOS_PATH, 'utf8')) as IScenario[];
+    } catch (err) {
+        console.log(err);
+        return scenarios;
+    }
+}
+
+/**
+ * @swagger
+ *
+ * /api/reference-list:
+ *   get:
+ *     summary: Получение списка референсных изображений сценариев
+ *     tags:
+ *       - Основные API
+ *     description: Returns scenario names and links to their reference images
+ *     produces:
+ *       - application/json
+ *     responses:
+ *      200:
+ *         description: Список сценариев с референсными изображениями
+ */
+export default function referenceList(req: Request, res: Response) {
+    let files: string[] = [];
+
+    try {
+        files = fs.readdirSync(REFERENCE_IMAGES_PATH)
+            .filter((file) => IMAGE_EXTENSION_REGEXP.test(file));
+    } catch (err) {
+        console.log(err);
+    }
+
+    const list = getReferenceScenarios().reduce<IReferenceListItem[]>((accumulator, scenario) => {
+        if (!scenario.label) {
+            return accumulator;
+        }
+
+        accumulator.push({
+            name: scenario.label,
+            image: getReferenceImage(scenario.label, files),
+        });
+
+        return accumulator;
+    }, []);
+
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Content-Type', 'application/json');
+    res.send(list);
+}

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1355,6 +1355,13 @@ eventemitter3@^5.0.1:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
   integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
 
+express-rate-limit@^8.5.2:
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.5.2.tgz#5922dbf76df2124611cea955d93432b37514b2f3"
+  integrity sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==
+  dependencies:
+    ip-address "^10.2.0"
+
 express@^4.16.3, express@^4.21.2:
   version "4.21.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.21.2.tgz#cf250e48362174ead6cea4a566abef0162c1ec32"
@@ -1806,6 +1813,11 @@ inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
+
+ip-address@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
+  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
 
 ip-address@^9.0.5:
   version "9.0.5"


### PR DESCRIPTION
- Add GET /api/reference-list route
- Return scenario names with matching reference image URLs
- Read scenarios from backstop config with local charts fallback
- Match Backstop reference filenames safely by scenario label
- Return null image when a scenario has no reference screenshot